### PR TITLE
fix $cdToDirectoryFirst=true bug in ApplyFaclsTask

### DIFF
--- a/Mage/Task/BuiltIn/Filesystem/ApplyFaclsTask.php
+++ b/Mage/Task/BuiltIn/Filesystem/ApplyFaclsTask.php
@@ -25,7 +25,6 @@ class ApplyFaclsTask extends AbstractTask implements IsReleaseAware
     public function run()
     {
         $releasesDirectory = $this->getConfig()->release('directory', 'releases');
-        $releasesDirectory = rtrim($this->getConfig()->deployment('to'), '/') . '/' . $releasesDirectory;
         $currentCopy = $releasesDirectory . '/' . $this->getConfig()->getReleaseId();
 
 


### PR DESCRIPTION
make ApplyFaclsTask compatible with default AbstractTask::runCommandRemote()parameter  $cdToDirectoryFirst=true
